### PR TITLE
Forbid to CRUD for SUPER-ADMIN role

### DIFF
--- a/src/main/java/com/icthh/xm/uaa/service/TenantRoleService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/TenantRoleService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.icthh.xm.commons.config.client.repository.TenantConfigRepository;
 import com.icthh.xm.commons.exceptions.BusinessException;
 import com.icthh.xm.commons.permission.config.PermissionProperties;
+import com.icthh.xm.commons.permission.constants.RoleConstant;
 import com.icthh.xm.commons.permission.domain.Permission;
 import com.icthh.xm.commons.permission.domain.Privilege;
 import com.icthh.xm.commons.permission.domain.Role;
@@ -39,6 +40,10 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
+
+import javax.validation.Valid;
+
+import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_FORBIDDEN_ROLE;
 
 /**
  * Service Implementation for managing Role.
@@ -90,7 +95,12 @@ public class TenantRoleService {
      * @param roleDto the role dto
      */
     @SneakyThrows
-    public void addRole(RoleDTO roleDto) {
+    public void addRole(@Valid RoleDTO roleDto) {
+
+        if (StringUtils.equalsIgnoreCase(RoleConstant.SUPER_ADMIN, roleDto.getRoleKey())) {
+            throw new BusinessException(ERROR_FORBIDDEN_ROLE, "Forbidden role key");
+        }
+
         Map<String, Role> roles = getRoles();
 
         if (null != roles.get(roleDto.getRoleKey())) {

--- a/src/main/java/com/icthh/xm/uaa/service/UserService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/UserService.java
@@ -2,7 +2,7 @@ package com.icthh.xm.uaa.service;
 
 import static com.icthh.xm.uaa.service.util.RandomUtil.generateActivationKey;
 import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_USER_DELETE_HIMSELF;
-import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_USER_DELETE_SUPER_ADMIN;
+import static com.icthh.xm.uaa.web.rest.util.VerificationUtils.assertNotSuperAdmin;
 
 import com.icthh.xm.commons.exceptions.BusinessException;
 import com.icthh.xm.commons.exceptions.EntityNotFoundException;
@@ -211,9 +211,7 @@ public class UserService {
             throw new BusinessException(ERROR_USER_DELETE_HIMSELF, "Forbidden to delete himself");
         }
         userRepository.findOneWithLoginsByUserKey(userKey).ifPresent(user -> {
-            if (RoleConstant.SUPER_ADMIN.equals(user.getRoleKey())) {
-                throw new BusinessException(ERROR_USER_DELETE_SUPER_ADMIN, "Forbidden to delete SUPER-ADMIN");
-            }
+            assertNotSuperAdmin(user.getRoleKey());
             socialService.deleteUserSocialConnection(user.getUserKey());
             userRepository.delete(user);
         });

--- a/src/main/java/com/icthh/xm/uaa/service/UserService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/UserService.java
@@ -2,6 +2,7 @@ package com.icthh.xm.uaa.service;
 
 import static com.icthh.xm.uaa.service.util.RandomUtil.generateActivationKey;
 import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_USER_DELETE_HIMSELF;
+import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_USER_DELETE_SUPER_ADMIN;
 
 import com.icthh.xm.commons.exceptions.BusinessException;
 import com.icthh.xm.commons.exceptions.EntityNotFoundException;
@@ -9,6 +10,7 @@ import com.icthh.xm.commons.lep.LogicExtensionPoint;
 import com.icthh.xm.commons.lep.spring.LepService;
 import com.icthh.xm.commons.logging.LoggingAspectConfig;
 import com.icthh.xm.commons.permission.annotation.FindWithPermission;
+import com.icthh.xm.commons.permission.constants.RoleConstant;
 import com.icthh.xm.commons.security.XmAuthenticationContextHolder;
 import com.icthh.xm.uaa.domain.OtpChannelType;
 import com.icthh.xm.uaa.domain.User;
@@ -209,6 +211,9 @@ public class UserService {
             throw new BusinessException(ERROR_USER_DELETE_HIMSELF, "Forbidden to delete himself");
         }
         userRepository.findOneWithLoginsByUserKey(userKey).ifPresent(user -> {
+            if (RoleConstant.SUPER_ADMIN.equals(user.getRoleKey())) {
+                throw new BusinessException(ERROR_USER_DELETE_SUPER_ADMIN, "Forbidden to delete SUPER-ADMIN");
+            }
             socialService.deleteUserSocialConnection(user.getUserKey());
             userRepository.delete(user);
         });

--- a/src/main/java/com/icthh/xm/uaa/service/dto/RoleDTO.java
+++ b/src/main/java/com/icthh/xm/uaa/service/dto/RoleDTO.java
@@ -7,11 +7,14 @@ import java.util.List;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.NotBlank;
+import org.hibernate.validator.constraints.NotEmpty;
 
 @Getter
 @Setter
 public class RoleDTO {
 
+    @NotEmpty
     private String roleKey;
     private String basedOn;
     private String description;

--- a/src/main/java/com/icthh/xm/uaa/web/constant/ErrorConstants.java
+++ b/src/main/java/com/icthh/xm/uaa/web/constant/ErrorConstants.java
@@ -15,4 +15,10 @@ public class ErrorConstants {
     public static final String TENANT_IS_SUSPENDED = "Tenant is suspended";
 
     public static final String ERROR_USER_DELETE_HIMSELF = "error.user.delete.himself";
+
+    public static final String ERROR_USER_DELETE_SUPER_ADMIN = "error.user.delete.super-admin";
+
+    public static final String ERROR_USER_CREATE_SUPER_ADMIN = "error.user.create.super-admin";
+
+    public static final String ERROR_USER_UPDATE_SUPER_ADMIN = "error.user.update.super-admin";
 }

--- a/src/main/java/com/icthh/xm/uaa/web/constant/ErrorConstants.java
+++ b/src/main/java/com/icthh/xm/uaa/web/constant/ErrorConstants.java
@@ -14,6 +14,8 @@ public class ErrorConstants {
     public static final String TENANT_NOT_SUPPLIED = "No tenant supplied";
     public static final String TENANT_IS_SUSPENDED = "Tenant is suspended";
 
+    public static final String ERROR_FORBIDDEN_ROLE = "error.role.forbidden";
+
     public static final String ERROR_USER_DELETE_HIMSELF = "error.user.delete.himself";
 
     public static final String ERROR_USER_DELETE_SUPER_ADMIN = "error.user.delete.super-admin";

--- a/src/main/java/com/icthh/xm/uaa/web/constant/ErrorConstants.java
+++ b/src/main/java/com/icthh/xm/uaa/web/constant/ErrorConstants.java
@@ -18,9 +18,5 @@ public class ErrorConstants {
 
     public static final String ERROR_USER_DELETE_HIMSELF = "error.user.delete.himself";
 
-    public static final String ERROR_USER_DELETE_SUPER_ADMIN = "error.user.delete.super-admin";
-
-    public static final String ERROR_USER_CREATE_SUPER_ADMIN = "error.user.create.super-admin";
-
-    public static final String ERROR_USER_UPDATE_SUPER_ADMIN = "error.user.update.super-admin";
+    public static final String ERROR_SUPER_ADMIN_FORBIDDEN_OPERATION = "error.super-admin.forbidden-operation";
 }

--- a/src/main/java/com/icthh/xm/uaa/web/rest/UserResource.java
+++ b/src/main/java/com/icthh/xm/uaa/web/rest/UserResource.java
@@ -2,6 +2,7 @@ package com.icthh.xm.uaa.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
 import com.icthh.xm.commons.exceptions.BusinessException;
+import com.icthh.xm.commons.permission.constants.RoleConstant;
 import com.icthh.xm.uaa.config.Constants;
 import com.icthh.xm.uaa.domain.OtpChannelType;
 import com.icthh.xm.uaa.domain.User;
@@ -13,6 +14,7 @@ import com.icthh.xm.uaa.service.dto.TfaEnableRequest;
 import com.icthh.xm.uaa.service.dto.TfaOtpChannelSpec;
 import com.icthh.xm.uaa.service.dto.UserDTO;
 import com.icthh.xm.uaa.service.dto.UserPublicDTO;
+import com.icthh.xm.uaa.web.constant.ErrorConstants;
 import com.icthh.xm.uaa.web.rest.util.HeaderUtil;
 import com.icthh.xm.uaa.web.rest.util.PaginationUtil;
 import io.github.jhipster.web.util.ResponseUtil;
@@ -106,6 +108,9 @@ public class UserResource {
                 .headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "idexists", "A new user cannot already have an ID"))
                 .body(null);
         }
+        if (RoleConstant.SUPER_ADMIN.equals(user.getRoleKey())) {
+            throw new BusinessException(ErrorConstants.ERROR_USER_CREATE_SUPER_ADMIN, "Super Admin could not be created");
+        }
         user.getLogins().forEach(userLogin ->
                                      userLoginRepository.findOneByLoginIgnoreCase(userLogin.getLogin())
                                          .ifPresent(s -> {
@@ -130,6 +135,9 @@ public class UserResource {
     @Timed
     @PreAuthorize("hasPermission({'id': #user.userKey, 'newUser': #user}, 'user', 'USER.UPDATE')")
     public ResponseEntity<UserDTO> updateUser(@Valid @RequestBody UserDTO user) {
+        if (RoleConstant.SUPER_ADMIN.equals(user.getRoleKey())) {
+            throw new BusinessException(ErrorConstants.ERROR_USER_UPDATE_SUPER_ADMIN, "Could not assign role " + RoleConstant.SUPER_ADMIN);
+        }
         Optional<UserDTO> updatedUser = userService.updateUser(user);
         updatedUser.ifPresent(userDTO -> produceEvent(userDTO, Constants.UPDATE_PROFILE_EVENT_TYPE));
         return ResponseUtil.wrapOrNotFound(updatedUser,

--- a/src/main/java/com/icthh/xm/uaa/web/rest/util/VerificationUtils.java
+++ b/src/main/java/com/icthh/xm/uaa/web/rest/util/VerificationUtils.java
@@ -1,0 +1,4 @@
+package com.icthh.xm.uaa.web.rest.util;
+
+public class AssertionUtils {
+}

--- a/src/main/java/com/icthh/xm/uaa/web/rest/util/VerificationUtils.java
+++ b/src/main/java/com/icthh/xm/uaa/web/rest/util/VerificationUtils.java
@@ -13,8 +13,8 @@ public class VerificationUtils {
         assertNotSuperAdmin(user.getRoleKey());
     }
 
-    public static void assertNotSuperAdmin(String userKey) {
-        if (RoleConstant.SUPER_ADMIN.equals(userKey)) {
+    public static void assertNotSuperAdmin(String roleKey) {
+        if (RoleConstant.SUPER_ADMIN.equals(roleKey)) {
             throw new BusinessException(ErrorConstants.ERROR_SUPER_ADMIN_FORBIDDEN_OPERATION, "This operation can not be applied to SUPER-ADMIN");
         }
     }

--- a/src/main/java/com/icthh/xm/uaa/web/rest/util/VerificationUtils.java
+++ b/src/main/java/com/icthh/xm/uaa/web/rest/util/VerificationUtils.java
@@ -1,4 +1,21 @@
 package com.icthh.xm.uaa.web.rest.util;
 
-public class AssertionUtils {
+import com.icthh.xm.commons.exceptions.BusinessException;
+import com.icthh.xm.commons.permission.constants.RoleConstant;
+import com.icthh.xm.uaa.service.dto.UserDTO;
+import com.icthh.xm.uaa.web.constant.ErrorConstants;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class VerificationUtils {
+
+    public static void assertNotSuperAdmin(UserDTO user) {
+        assertNotSuperAdmin(user.getRoleKey());
+    }
+
+    public static void assertNotSuperAdmin(String userKey) {
+        if (RoleConstant.SUPER_ADMIN.equals(userKey)) {
+            throw new BusinessException(ErrorConstants.ERROR_SUPER_ADMIN_FORBIDDEN_OPERATION, "This operation can not be applied to SUPER-ADMIN");
+        }
+    }
 }

--- a/src/test/java/com/icthh/xm/uaa/cucumber/stepdefs/UserStepDefs.java
+++ b/src/test/java/com/icthh/xm/uaa/cucumber/stepdefs/UserStepDefs.java
@@ -1,5 +1,6 @@
 package com.icthh.xm.uaa.cucumber.stepdefs;
 
+import static com.icthh.xm.commons.permission.constants.RoleConstant.SUPER_ADMIN;
 import static com.icthh.xm.uaa.config.Constants.HEADER_TENANT;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
@@ -39,7 +40,7 @@ public class UserStepDefs extends StepDefs {
     @WithMockUser
     public void i_search_user_admin(String userKey, String tenant) throws Throwable {
         UserDetails userDetails = new DomainUserDetails("xm", "P@ssw0rd",
-            Collections.singletonList(new SimpleGrantedAuthority("SUPER-ADMIN")), "XM", "xm", false, null, null, false, null);
+            Collections.singletonList(new SimpleGrantedAuthority(SUPER_ADMIN)), "XM", "xm", false, null, null, false, null);
         actions = restUserMockMvc.perform(get("/api/users/" + userKey).with(user(userDetails))
             .header(HEADER_TENANT, tenant)
             .accept(MediaType.APPLICATION_JSON));

--- a/src/test/java/com/icthh/xm/uaa/service/TenantRoleServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/uaa/service/TenantRoleServiceUnitTest.java
@@ -1,5 +1,6 @@
 package com.icthh.xm.uaa.service;
 
+import static com.icthh.xm.commons.permission.constants.RoleConstant.SUPER_ADMIN;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -103,7 +104,7 @@ public class TenantRoleServiceUnitTest {
         when(tenantConfigRepository.getConfigFullPath(TENANT, rolesPath))
             .thenReturn(readConfigFile("/config/tenants/XM/roles.yml"));
         assertEquals("test", tenantRoleService.getRoles().get("ROLE_USER").getDescription());
-        assertEquals("test2", tenantRoleService.getRoles().get("SUPER-ADMIN").getDescription());
+        assertEquals("test2", tenantRoleService.getRoles().get(SUPER_ADMIN).getDescription());
 
         when(tenantConfigRepository.getConfigFullPath(TENANT, rolesPath))
             .thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));

--- a/src/test/java/com/icthh/xm/uaa/web/rest/UserResourceIntTest.java
+++ b/src/test/java/com/icthh/xm/uaa/web/rest/UserResourceIntTest.java
@@ -3,9 +3,7 @@ package com.icthh.xm.uaa.web.rest;
 import static com.icthh.xm.commons.lep.XmLepConstants.THREAD_CONTEXT_KEY_TENANT_CONTEXT;
 import static com.icthh.xm.commons.lep.XmLepScriptConstants.BINDING_KEY_AUTH_CONTEXT;
 import static com.icthh.xm.uaa.UaaTestConstants.DEFAULT_TENANT_KEY_VALUE;
-import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_USER_CREATE_SUPER_ADMIN;
-import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_USER_DELETE_SUPER_ADMIN;
-import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_USER_UPDATE_SUPER_ADMIN;
+import static com.icthh.xm.uaa.web.constant.ErrorConstants.ERROR_SUPER_ADMIN_FORBIDDEN_OPERATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.Matchers.hasItem;
@@ -331,7 +329,7 @@ public class UserResourceIntTest {
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(managedUserVM)))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value(ERROR_USER_CREATE_SUPER_ADMIN));
+            .andExpect(jsonPath("$.error").value(ERROR_SUPER_ADMIN_FORBIDDEN_OPERATION));
 
         // Validate that the new SUPER-ADMIN wasn't created
         List<User> userList = userRepository.findAll();
@@ -607,7 +605,7 @@ public class UserResourceIntTest {
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
             .content(TestUtil.convertObjectToJsonBytes(managedUserVM)))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value(ERROR_USER_UPDATE_SUPER_ADMIN));
+            .andExpect(jsonPath("$.error").value(ERROR_SUPER_ADMIN_FORBIDDEN_OPERATION));
     }
 
 
@@ -707,7 +705,7 @@ public class UserResourceIntTest {
         restUserMockMvc.perform(delete("/api/users/{userKey}", superAdminUser.getUserKey())
             .accept(TestUtil.APPLICATION_JSON_UTF8))
             .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value(ERROR_USER_DELETE_SUPER_ADMIN));
+            .andExpect(jsonPath("$.error").value(ERROR_SUPER_ADMIN_FORBIDDEN_OPERATION));
 
         // Validate that super-admin wasn't deleted
         List<User> userList = userRepository.findAll();


### PR DESCRIPTION
This pull request does
- forbid to delete user with role SUPER-ADMIN
- forbid to create user with role SUPER-ADMIN
- forbid to update user account to provide SUPER-ADMIN

there are only 1 super admin, as @major13ua say