### PR TITLE
Enabled static analyze and update checkstyle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,20 +187,36 @@ liquibase {
 }
 
 checkstyle {
-    toolVersion = "7.6.1"
-    ignoreFailures = true
+    checkstyleNohttp.enabled = false
+    toolVersion = "8.26"
+    ignoreFailures = false
     configFile = rootProject.file('./qa/checkstyle.xml')
+    configProperties.checkstyleSuppressionsPath = rootProject.file('./qa/suppressions.xml').absolutePath
 }
 
 spotbugs {
-    ignoreFailures = true
+    ignoreFailures = false
 }
 
 pmd {
     rulePriority = 3
     toolVersion = '5.5.4'
-    ignoreFailures = true
+    ignoreFailures = false
     ruleSetFiles = files("./qa/pmd.xml")
+}
+
+tasks.withType(Pmd){
+    reports{
+        xml.enabled=false
+        html.enabled=true
+    }
+}
+
+tasks.withType(com.github.spotbugs.SpotBugsTask){
+    reports{
+        xml.enabled=false
+        html.enabled=true
+    }
 }
 
 configurations {
@@ -301,6 +317,7 @@ dependencies {
     }
 
     // XM custom dependencies
+    implementation "org.projectlombok:lombok:${lombok_version}"
     compileOnly "org.projectlombok:lombok:${lombok_version}"
     annotationProcessor "org.projectlombok:lombok:${lombok_version}"
 

--- a/qa/checkstyle.xml
+++ b/qa/checkstyle.xml
@@ -11,9 +11,14 @@
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
-        <module name="FileTabCharacter">
-            <property name="eachLine" value="true"/>
-        </module>
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
 
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
@@ -27,10 +32,7 @@
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-        </module>
+
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>
         <module name="NoLineWrap"/>
@@ -187,7 +189,7 @@
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="minLineCount" value="2"/>
+<!--            <property name="minLineCount" value="2"/>-->
             <property name="allowedAnnotations" value="Override, Test"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>

--- a/qa/suppressions.xml
+++ b/qa/suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress files="." checks="[NoHttp]"/>
+</suppressions>


### PR DESCRIPTION
Current situation of issues in current ms:

1. Main source code
   Checkstyle files with violations: 106
   Checkstyle violations by severity: [warning:728]

2. Test source code
   Checkstyle files with violations: 43
   Checkstyle violations by severity: [warning:470]

3. spotbugsMain
   Total	69

4. spotbugsTest
   Total	19

So the above issues have to be solved to go with development further with static analyzes.

Please approve fix all of these changes in code!