### PR TITLE
fix for default AD role. During user login-in, if his role in AD has …

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 rootProject.name=uaa
-version=2.0.18
+version=2.0.19
 profile=dev
 
 # Build properties

--- a/src/main/java/com/icthh/xm/uaa/security/ldap/UaaLdapUserDetailsContextMapper.java
+++ b/src/main/java/com/icthh/xm/uaa/security/ldap/UaaLdapUserDetailsContextMapper.java
@@ -1,5 +1,8 @@
 package com.icthh.xm.uaa.security.ldap;
 
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
+
 import com.icthh.xm.uaa.domain.User;
 import com.icthh.xm.uaa.domain.UserLogin;
 import com.icthh.xm.uaa.domain.UserLoginType;
@@ -7,6 +10,16 @@ import com.icthh.xm.uaa.domain.properties.TenantProperties;
 import com.icthh.xm.uaa.security.DomainUserDetailsService;
 import com.icthh.xm.uaa.service.UserService;
 import com.icthh.xm.uaa.service.dto.UserDTO;
+import java.math.BigInteger;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.naming.NamingException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -14,16 +27,6 @@ import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
-
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import java.math.BigInteger;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import static java.util.Objects.nonNull;
-import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 
 @AllArgsConstructor
 @Slf4j
@@ -64,14 +67,14 @@ public class UaaLdapUserDetailsContextMapper extends LdapUserDetailsMapper {
         userLogin.setLogin(username);
         userLogin.setTypeKey(UserLoginType.NICKNAME.getValue());
         userDTO.setLogins(Collections.singletonList(userLogin));
-        userDTO.setRoleKey(defaultIfEmpty(mapRole(roleConf, authorities), roleConf.getDefaultRole()));
+        userDTO.setRoleKey(mapRole(roleConf, authorities).orElse(roleConf.getDefaultRole()));
         userService.createUser(userDTO);
     }
 
     private void updateUser(DirContextOperations ctx, User user, Collection<? extends GrantedAuthority> authorities) {
         TenantProperties.Ldap.Role roleConf = ldapConf.getRole();
-        String mappedRole = defaultIfEmpty(mapRole(roleConf, authorities), user.getRoleKey());
-        mappedRole = defaultIfEmpty(mappedRole, roleConf.getDefaultRole());
+        String mappedRole = mapRole(roleConf, authorities)
+            .orElseGet(() -> defaultIfEmpty(user.getRoleKey(), roleConf.getDefaultRole()));
         log.info("Mapped role from ldap [{}], current role [{}]", mappedRole, user.getRoleKey());
         String imageUrl = parseImageUrl(ctx);
 
@@ -86,7 +89,7 @@ public class UaaLdapUserDetailsContextMapper extends LdapUserDetailsMapper {
         return !mappedRole.equals(user.getRoleKey()) || !StringUtils.equals(user.getImageUrl(), imageUrl);
     }
 
-    private String mapRole(TenantProperties.Ldap.Role roleConf, Collection<? extends GrantedAuthority> authorities) {
+    private Optional<String> mapRole(TenantProperties.Ldap.Role roleConf, Collection<? extends GrantedAuthority> authorities) {
         LinkedList<String> mappedRoles = new LinkedList<>();
         Map<String, String> mappingConf = roleConf.getMapping();
 
@@ -98,12 +101,12 @@ public class UaaLdapUserDetailsContextMapper extends LdapUserDetailsMapper {
                 }
             });
         }
-        String mappedXmRole = mappedRoles.isEmpty() ? null : mappedRoles.getLast();
+        Optional<String> mappedXmRole = mappedRoles.isEmpty() ? Optional.empty() : Optional.of(mappedRoles.getLast());
         if (mappedRoles.size() > BigInteger.ONE.intValue()) {
             log.warn("More than 1 role was matched: {}. Will be used the latest one: {}", mappedRoles, mappedXmRole);
         }
 
-        log.info("Mapped role: {}", mappedXmRole);
+        log.info("Mapped role: {}", mappedXmRole.orElse(null));
         return mappedXmRole;
     }
 

--- a/src/test/java/com/icthh/xm/uaa/security/ldap/UaaLdapUserDetailsContextMapperTest.java
+++ b/src/test/java/com/icthh/xm/uaa/security/ldap/UaaLdapUserDetailsContextMapperTest.java
@@ -1,0 +1,99 @@
+package com.icthh.xm.uaa.security.ldap;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.icthh.xm.uaa.domain.User;
+import com.icthh.xm.uaa.domain.properties.TenantProperties;
+import com.icthh.xm.uaa.security.DomainUserDetailsService;
+import com.icthh.xm.uaa.service.UserService;
+import com.icthh.xm.uaa.service.dto.UserDTO;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.ldap.core.DirContextOperations;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+@RunWith(MockitoJUnitRunner.class)
+public class UaaLdapUserDetailsContextMapperTest {
+
+    private static final String LOGIN = "Homer";
+    public static final Map<String, String> GROUP_MAPPING = Map.of(
+        "GROUP1", "SUPER_ADMIN",
+        "GROUP2", "LOSER"
+    );
+    @Mock
+    UserService userService;
+
+    @Mock
+    DirContextOperations ctx;
+
+    @Mock
+    TenantProperties.Ldap ldapConf;
+
+    @Mock
+    DomainUserDetailsService userDetailsService;
+
+    @InjectMocks
+    UaaLdapUserDetailsContextMapper uaaLdapUserDetailsContextMapper;
+
+    @Test
+    public void userRoleMustNotChangeDuringLogin() {
+        whenFindUserByLogin();
+        when(ldapConf.getRole()).thenReturn(new TenantProperties.Ldap.Role("DEFAULT_ROLE", null));
+        uaaLdapUserDetailsContextMapper.mapUserFromContext(ctx, LOGIN, List.of());
+        verify(userDetailsService).loadUserByUsername(eq(LOGIN));
+        verify(userService, never()).saveUser(any(User.class));
+    }
+
+    @Test
+    public void useRoleMustChangeToOneFromADGroup() {
+        whenFindUserByLogin();
+        when(ldapConf.getRole()).thenReturn(new TenantProperties.Ldap.Role("DEFAULT_ROLE", GROUP_MAPPING));
+        uaaLdapUserDetailsContextMapper.mapUserFromContext(ctx, LOGIN, newArrayList((GrantedAuthority) () -> "GROUP1"));
+        verify(userDetailsService).loadUserByUsername(eq(LOGIN));
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userService, times(1))
+            .saveUser(captor.capture());
+        User user = captor.getValue();
+        assertEquals(user.getRoleKey(), "SUPER_ADMIN");
+    }
+
+
+    @Test
+    public void userMustBeCreatedWithDefaultRole() {
+        when(ldapConf.getRole()).thenReturn(new TenantProperties.Ldap.Role("DEFAULT_ROLE", null));
+        when(ldapConf.getAttribute()).thenReturn(new TenantProperties.Ldap.Attribute("Homer", "Simpson"));
+        uaaLdapUserDetailsContextMapper.mapUserFromContext(ctx, LOGIN, newArrayList((GrantedAuthority) () -> "GROUP1"));
+        verify(userDetailsService).loadUserByUsername(eq(LOGIN));
+
+        ArgumentCaptor<UserDTO> captor = ArgumentCaptor.forClass(UserDTO.class);
+        verify(userService, times(1))
+            .createUser(captor.capture());
+        UserDTO user = captor.getValue();
+        assertEquals(user.getRoleKey(), "DEFAULT_ROLE");
+    }
+
+    private void whenFindUserByLogin() {
+        when(userService.findOneByLogin(LOGIN)).thenAnswer(invocation -> {
+            User user = new User();
+            user.setRoleKey("ROLE_ADMIN");
+            return Optional.of(user);
+        });
+    }
+}

--- a/src/test/java/com/icthh/xm/uaa/security/ldap/UaaLdapUserDetailsContextMapperTest.java
+++ b/src/test/java/com/icthh/xm/uaa/security/ldap/UaaLdapUserDetailsContextMapperTest.java
@@ -1,7 +1,9 @@
 package com.icthh.xm.uaa.security.ldap;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Optional.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -53,11 +55,12 @@ public class UaaLdapUserDetailsContextMapperTest {
 
     @Test
     public void userRoleMustNotChangeDuringLogin() {
-        whenFindUserByLogin();
+        User user = whenFindUserByLogin();
         when(ldapConf.getRole()).thenReturn(new TenantProperties.Ldap.Role("DEFAULT_ROLE", null));
         uaaLdapUserDetailsContextMapper.mapUserFromContext(ctx, LOGIN, List.of());
         verify(userDetailsService).loadUserByUsername(eq(LOGIN));
         verify(userService, never()).saveUser(any(User.class));
+        assertEquals(user.getRoleKey(), "ROLE_ADMIN");
     }
 
     @Test
@@ -89,11 +92,10 @@ public class UaaLdapUserDetailsContextMapperTest {
         assertEquals(user.getRoleKey(), "DEFAULT_ROLE");
     }
 
-    private void whenFindUserByLogin() {
-        when(userService.findOneByLogin(LOGIN)).thenAnswer(invocation -> {
-            User user = new User();
-            user.setRoleKey("ROLE_ADMIN");
-            return Optional.of(user);
-        });
+    private User whenFindUserByLogin() {
+        User user = new User();
+        user.setRoleKey("ROLE_ADMIN");
+        when(userService.findOneByLogin(LOGIN)).thenAnswer(invocation -> of(user));
+        return user;
     }
 }


### PR DESCRIPTION
…changed but his XM role is not in configured AD group then he will stay with existing role