### PR TITLE
Add password reset after account disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- openjdk11
+- oraclejdk11
 install: true
 addons:
   sonarcloud:
@@ -19,8 +19,8 @@ script:
   - export DOCKER_REPO=$(echo  -n $TRAVIS_REPO_SLUG | sed -e 's/^xm-online\//xmonline\//g')
   - export IMAGE_BRANCH=$(echo -n $TRAVIS_BRANCH | sed -e 's/\//-/g')
   - export PROJECT_VERSION="$IMAGE_BRANCH"
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; 
-    then 
+  - if [ "$TRAVIS_PULL_REQUEST" == "false" ];
+    then
         PROJECT_VERSION=$(./gradlew -q  getProjectVersion);
         export SONAR_PK=$(echo  -n $TRAVIS_REPO_SLUG | sed -e 's/\//:/g');
         ./gradlew -x test --no-daemon sonarqube -Dsonar.projectKey="$SONAR_PK"

--- a/src/main/java/com/icthh/xm/uaa/domain/User.java
+++ b/src/main/java/com/icthh/xm/uaa/domain/User.java
@@ -1,6 +1,7 @@
 package com.icthh.xm.uaa.domain;
 
 import static com.google.common.collect.Iterables.getFirst;
+import static java.util.Objects.requireNonNullElse;
 import static org.apache.commons.collections.CollectionUtils.isNotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -159,6 +160,10 @@ public class User extends AbstractAuditingEntity implements Serializable {
 
     @Column(name = "password_attempts")
     private Integer passwordAttempts;
+
+    public Integer getPasswordAttempts() {
+        return requireNonNullElse(passwordAttempts, 0);
+    }
 
     // TODO refactor, put EMAIL type to configuration
     public String getEmail() {

--- a/src/main/java/com/icthh/xm/uaa/service/UserService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/UserService.java
@@ -678,7 +678,8 @@ public class UserService {
             userLoginRepository.findOneByLoginIgnoreCase(username)
                 .map(UserLogin::getUser)
                 .map(User::incrementPasswordAttempts)
-                .ifPresent(user -> self.passwordAttemptsExceeded(user, maxPasswordAttempts));
+                .filter(user -> user.getPasswordAttempts().equals(maxPasswordAttempts))
+                .ifPresent(self::passwordAttemptsExceeded);
         }
     }
 
@@ -687,9 +688,7 @@ public class UserService {
     }
 
     @LogicExtensionPoint(value = "PasswordAttemptsExceeded")
-    public void passwordAttemptsExceeded(User user, Integer maxPasswordAttempts) {
-        if (user.getPasswordAttempts().equals(maxPasswordAttempts)) {
-            user.setActivated(false);
-        }
+    public void passwordAttemptsExceeded(User user) {
+        user.setActivated(false);
     }
 }

--- a/src/main/java/com/icthh/xm/uaa/service/UserService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/UserService.java
@@ -690,5 +690,6 @@ public class UserService {
     @LogicExtensionPoint(value = "PasswordAttemptsExceeded")
     public void passwordAttemptsExceeded(User user) {
         user.setActivated(false);
+        user.resetPasswordAttempts();
     }
 }

--- a/src/test/java/com/icthh/xm/uaa/service/UserServiceIntTest.java
+++ b/src/test/java/com/icthh/xm/uaa/service/UserServiceIntTest.java
@@ -361,7 +361,7 @@ public class UserServiceIntTest {
         userService.increaseFailedPasswordAttempts(userLogin.getLogin());
 
         assertThat(user.isActivated()).isFalse();
-        assertThat(user.getPasswordAttempts()).isEqualTo(3);
+        assertThat(user.getPasswordAttempts()).isEqualTo(0);
 
         userRepository.delete(user);
     }

--- a/src/test/java/com/icthh/xm/uaa/service/UserServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/uaa/service/UserServiceUnitTest.java
@@ -347,7 +347,7 @@ public class UserServiceUnitTest {
 
         service.increaseFailedPasswordAttempts(USER_LOGIN);
 
-        assertThat(user.getPasswordAttempts()).isEqualTo(3);
+        assertThat(user.getPasswordAttempts()).isEqualTo(0);
         assertThat(user.isActivated()).isFalse();
 
         verify(tenantPropertiesService).getTenantProps();


### PR DESCRIPTION
# What? Why?
**Before:**
At the moment, after disabling an account password attempts are not reset, therefore, after activating the account the user can enter the password as many times as he wants.

**After:**
The user's password will be reset when the account is disabled.