### PR TITLE
added LEP to otpService and modified logic for #prepareOtpRequest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=uaa
 
-version=2.2.61
+version=2.2.62
 profile=dev
 
 # Build properties

--- a/src/main/java/com/icthh/xm/uaa/config/Constants.java
+++ b/src/main/java/com/icthh/xm/uaa/config/Constants.java
@@ -58,6 +58,9 @@ public final class Constants {
     public static final String TOKEN_AUTH_DETAILS_TFA_OTP_CHANNEL_TYPE = "tfaOtpChannel";
     public static final String TOKEN_AUTH_DETAILS_TFA_OTP_ID = "otpId";
     public static final String TOKEN_AUTH_DETAILS_TFA_DESTINATION = "destination";
+    public static final String TOKEN_AUTH_DETAILS_TFA_OTP_TYPE_KEY = "tfaOtpTypeKey";
+    public static final String TOKEN_AUTH_DETAILS_TFA_OTP_RECEIVER_TYPE_KEY = "tfaOtpReceiverTypeKey";
+    public static final String TOKEN_AUTH_DETAILS_TFA_OTP_GENERATE_URL = "tfaOtpGenerateUrl";
 
     public static final String ACCESS_TOKEN_URL = "http://uaa/oauth/token";
 

--- a/src/main/java/com/icthh/xm/uaa/service/otp/OtpService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/otp/OtpService.java
@@ -43,7 +43,7 @@ public class OtpService {
     private final OtpServiceClient otpServiceClient;
 
     @LoggingAspectConfig(inputExcludeParams = "userDetails")
-    @LogicExtensionPoint("prepareOtpRequest")
+    @LogicExtensionPoint("PrepareOtpRequest")
     public Long prepareOtpRequest(@NonNull final DomainUserDetails userDetails) {
         log.debug("Prepare otp request for user: {}", userDetails);
         Map<String, String> additionalDetails = userDetails.getAdditionalDetails();
@@ -80,7 +80,7 @@ public class OtpService {
     }
 
     @LoggingAspectConfig(inputExcludeParams = "otp")
-    @LogicExtensionPoint("checkOtpRequest")
+    @LogicExtensionPoint("CheckOtpRequest")
     public boolean checkOtpRequest(Long otpId, String otp) {
 
         String url = tenantPropertiesService.getTenantProps().getSecurity().getTfaOtpCheckUrl();

--- a/src/main/java/com/icthh/xm/uaa/service/otp/OtpService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/otp/OtpService.java
@@ -48,6 +48,7 @@ public class OtpService {
         log.debug("Prepare otp request for user: {}", userDetails);
         Map<String, String> additionalDetails = userDetails.getAdditionalDetails();
         log.debug("Additional details: {}", additionalDetails);
+
         String url = Optional.ofNullable(additionalDetails.get(TOKEN_AUTH_DETAILS_TFA_OTP_GENERATE_URL))
             .orElse(tenantPropertiesService.getTenantProps().getSecurity().getTfaOtpGenerateUrl());
         if (StringUtils.isEmpty(url)) {
@@ -55,6 +56,7 @@ public class OtpService {
             throw new BusinessException("error.get.otp.password.url", "Can not get otp password url");
         }
         log.debug("Otp url: {}", url);
+
         String tfaOtpTypeKey = Optional.ofNullable(additionalDetails.get(TOKEN_AUTH_DETAILS_TFA_OTP_TYPE_KEY))
             .orElse(tenantPropertiesService.getTenantProps().getSecurity().getTfaOtpTypeKey());
         log.info("tfaOtpTypeKey: {}", tfaOtpTypeKey);
@@ -95,6 +97,7 @@ public class OtpService {
     private UserLoginDto findUserLogin(final DomainUserDetails userDetails, final String receiverTypeKey) {
         log.info("Find user login by receiverTypeKey: {}", receiverTypeKey);
         UserLoginDto userLogin;
+
         if (ReceiverTypeKey.PHONE_NUMBER.getValue().equalsIgnoreCase(receiverTypeKey)) {
             userLogin = userDetails.getLogins().stream()
                 .filter(UserLoginDto -> UserLoginType.MSISDN.getValue().equalsIgnoreCase(UserLoginDto.getTypeKey()))


### PR DESCRIPTION
There was a need to send non-standard message text for OTP. 
So we decided to change the hardcode of typeKey and receiver from tenantConfig and take the custom value from DomainUserDetails (since we can control its contents via @lep on our side).
In addition, we added the @LogicExtensionPoint annotation and extended the logic for getting the login. 