### PR TITLE
XM1-35851: Add health indicator for check exists kafka topics;

### DIFF
--- a/src/main/java/com/icthh/xm/uaa/config/ApplicationProperties.java
+++ b/src/main/java/com/icthh/xm/uaa/config/ApplicationProperties.java
@@ -65,7 +65,7 @@ public class ApplicationProperties {
 
     @Getter
     @Setter
-    private static class Retry {
+    public static class Retry {
 
         private int maxAttempts;
         private long delay;

--- a/src/main/java/com/icthh/xm/uaa/health_check/KafkaTopicsHealthIndicator.java
+++ b/src/main/java/com/icthh/xm/uaa/health_check/KafkaTopicsHealthIndicator.java
@@ -1,0 +1,47 @@
+package com.icthh.xm.uaa.health_check;
+
+import com.icthh.xm.uaa.config.ApplicationProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.KafkaFuture;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaTopicsHealthIndicator implements HealthIndicator {
+
+    private final ApplicationProperties applicationProperties;
+    private final KafkaProperties kafkaProperties;
+
+
+    @Override
+    public Health health() {
+        final List<String> topicsToCheck = List.of(
+                applicationProperties.getKafkaSystemTopic(),
+                applicationProperties.getKafkaSystemQueue()
+        );
+
+        try (AdminClient adminClient = AdminClient.create(kafkaProperties.buildConsumerProperties())) {
+            DescribeTopicsResult result = adminClient.describeTopics(topicsToCheck);
+            Map<String, KafkaFuture<TopicDescription>> values = result.values();
+
+            for (String topic : topicsToCheck) {
+                KafkaFuture<TopicDescription> future = values.get(topic);
+                future.get();
+            }
+
+            return Health.up().withDetail("topics", topicsToCheck).build();
+        } catch (Exception e) {
+            return Health.down(e).withDetail("topics", topicsToCheck).build();
+        }
+    }
+}

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -192,8 +192,8 @@ application:
     kafka-metadata-max-age: 60000 #in milliseconds
     auto-system-queue-enabled: true
     retry:
-        max-attempts: 3
-        delay: 1000 #in milliseconds
+        max-attempts: 10
+        delay: 2000 #in milliseconds
         multiplier: 2
     reCaptcha:
         url: https://www.google.com/recaptcha/api/siteverify


### PR DESCRIPTION
1) Add health check and run app only after created all topics. Avoid crash app when topic hasn't created yet.