### PR TITLE
Change defaultTtl in api key properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=uaa
 
-version=2.2.85
+version=2.2.86
 profile=dev
 
 # Build properties

--- a/src/main/java/com/icthh/xm/uaa/domain/properties/TenantProperties.java
+++ b/src/main/java/com/icthh/xm/uaa/domain/properties/TenantProperties.java
@@ -151,7 +151,7 @@ public class TenantProperties {
 
         @Data
         public static class ApiKey {
-            private Duration defaultTtl;
+            private Long defaultTtlInSeconds;
             private String secret;
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.2.86
  * API key default time-to-live configuration now uses seconds-based format

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xm-online/xm-uaa/pull/291)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->