### PR TITLE
make jwks 'use' parameter optional according to the specification

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=uaa
 
-version=2.2.87
+version=2.2.88
 profile=dev
 
 # Build properties

--- a/src/main/java/com/icthh/xm/uaa/security/oauth2/idp/jwk/JwkSetConverter.java
+++ b/src/main/java/com/icthh/xm/uaa/security/oauth2/idp/jwk/JwkSetConverter.java
@@ -148,9 +148,8 @@ public class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition
 		// use
 		JwkDefinition.PublicKeyUse publicKeyUse =
 				JwkDefinition.PublicKeyUse.fromValue(attributes.get(PUBLIC_KEY_USE));
-		if (!JwkDefinition.PublicKeyUse.SIG.equals(publicKeyUse)) {
-			throw new JwkException((publicKeyUse != null ? publicKeyUse.value() : "unknown") +
-					" (" + PUBLIC_KEY_USE + ") is currently not supported.");
+		if (publicKeyUse != null && !JwkDefinition.PublicKeyUse.SIG.equals(publicKeyUse)) {
+			throw new JwkException(publicKeyUse.value() + " (" + PUBLIC_KEY_USE + ") is currently not supported.");
 		}
 
 		// alg

--- a/src/main/java/com/icthh/xm/uaa/security/oauth2/idp/jwk/JwkSetConverter.java
+++ b/src/main/java/com/icthh/xm/uaa/security/oauth2/idp/jwk/JwkSetConverter.java
@@ -197,9 +197,8 @@ public class JwkSetConverter implements Converter<InputStream, Set<JwkDefinition
 		// use
 		JwkDefinition.PublicKeyUse publicKeyUse =
 				JwkDefinition.PublicKeyUse.fromValue(attributes.get(PUBLIC_KEY_USE));
-		if (!JwkDefinition.PublicKeyUse.SIG.equals(publicKeyUse)) {
-			throw new JwkException((publicKeyUse != null ? publicKeyUse.value() : "unknown") +
-					" (" + PUBLIC_KEY_USE + ") is currently not supported.");
+		if (publicKeyUse != null && !JwkDefinition.PublicKeyUse.SIG.equals(publicKeyUse)) {
+			throw new JwkException(publicKeyUse.value() + " (" + PUBLIC_KEY_USE + ") is currently not supported.");
 		}
 
 		// alg


### PR DESCRIPTION
https://datatracker.ietf.org/doc/html/rfc7517#section-4.2

<img width="746" height="618" alt="image" src="https://github.com/user-attachments/assets/908d439f-c998-4844-8687-665bb634ceac" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project version to 2.2.88.

* **Bug Fixes**
  * Relaxed OAuth2 JWK validation so keys with unspecified usage are handled correctly and only unsupported explicit usages are rejected, improving token/key acceptance and interoperability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xm-online/xm-uaa/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->