### PR TITLE
fix: Set refresh token validity seconds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=uaa
 
-version=2.2.89
+version=2.2.90
 profile=dev
 
 # Build properties

--- a/src/main/java/com/icthh/xm/uaa/domain/Client.java
+++ b/src/main/java/com/icthh/xm/uaa/domain/Client.java
@@ -93,5 +93,13 @@ public class Client extends AbstractAuditingEntity implements Serializable {
         return scopes;
     }
 
+    public Client accessTokenValiditySeconds(Integer accessTokenValiditySeconds) {
+        this.accessTokenValiditySeconds = accessTokenValiditySeconds;
+        return this;
+    }
 
+    public Client refreshTokenValiditySeconds(Integer refreshTokenValiditySeconds) {
+        this.refreshTokenValiditySeconds = refreshTokenValiditySeconds;
+        return this;
+    }
 }

--- a/src/main/java/com/icthh/xm/uaa/service/ClientService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/ClientService.java
@@ -77,6 +77,7 @@ public class ClientService {
         newClient.setRoleKey(client.getRoleKey());
         newClient.setDescription(client.getDescription());
         newClient.setAccessTokenValiditySeconds(client.getAccessTokenValiditySeconds());
+        newClient.setRefreshTokenValiditySeconds(client.getRefreshTokenValiditySeconds());
         newClient.setScopes(client.getScopes());
         return clientRepository.save(newClient);
     }
@@ -100,6 +101,7 @@ public class ClientService {
             client.setRoleKey(updatedClient.getRoleKey());
             client.setDescription(updatedClient.getDescription());
             client.setAccessTokenValiditySeconds(updatedClient.getAccessTokenValiditySeconds());
+            client.setRefreshTokenValiditySeconds(updatedClient.getRefreshTokenValiditySeconds());
             client.setScopes(updatedClient.getScopes());
             return client;
         }).orElseThrow(() -> new EntityNotFoundException("Entity not found"));

--- a/src/test/java/com/icthh/xm/uaa/web/rest/ClientResourceIntTest.java
+++ b/src/test/java/com/icthh/xm/uaa/web/rest/ClientResourceIntTest.java
@@ -87,6 +87,12 @@ public class ClientResourceIntTest {
     private static final String DEFAULT_DESCRIPTION = "AAAAAAAAAA";
     private static final String UPDATED_DESCRIPTION = "BBBBBBBBBB";
 
+    private static final Integer DEFAULT_ACCESS_TOKEN_VALIDITY = 3600;
+    private static final Integer UPDATED_ACCESS_TOKEN_VALIDITY = 7200;
+
+    private static final Integer DEFAULT_REFRESH_TOKEN_VALIDITY = 86400;
+    private static final Integer UPDATED_REFRESH_TOKEN_VALIDITY = 172800;
+
     private static final Instant DEFAULT_CREATED_DATE = Instant.ofEpochMilli(0L);
 
     private static final Instant DEFAULT_UPDATED_DATE = Instant.ofEpochMilli(0L);
@@ -166,7 +172,9 @@ public class ClientResourceIntTest {
             .clientId(DEFAULT_CLIENT_ID)
             .clientSecret(DEFAULT_CLIENT_SECRET)
             .roleKey(DEFAULT_ROLE_KEY)
-            .description(DEFAULT_DESCRIPTION);
+            .description(DEFAULT_DESCRIPTION)
+            .accessTokenValiditySeconds(DEFAULT_ACCESS_TOKEN_VALIDITY)
+            .refreshTokenValiditySeconds(DEFAULT_REFRESH_TOKEN_VALIDITY);
         return client;
     }
 
@@ -241,6 +249,8 @@ public class ClientResourceIntTest {
         assertThat(encoder.matches(DEFAULT_CLIENT_SECRET, testClient.getClientSecret())).isTrue();
         assertThat(testClient.getRoleKey()).isEqualTo(DEFAULT_ROLE_KEY);
         assertThat(testClient.getDescription()).isEqualTo(DEFAULT_DESCRIPTION);
+        assertThat(testClient.getAccessTokenValiditySeconds()).isEqualTo(DEFAULT_ACCESS_TOKEN_VALIDITY);
+        assertThat(testClient.getRefreshTokenValiditySeconds()).isEqualTo(DEFAULT_REFRESH_TOKEN_VALIDITY);
     }
 
     @Test
@@ -317,6 +327,8 @@ public class ClientResourceIntTest {
         updatedClient.setClientSecret(UPDATED_CLIENT_SECRET);
         updatedClient.setRoleKey(UPDATED_ROLE_KEY);
         updatedClient.setDescription(UPDATED_DESCRIPTION);
+        updatedClient.setAccessTokenValiditySeconds(UPDATED_ACCESS_TOKEN_VALIDITY);
+        updatedClient.setRefreshTokenValiditySeconds(UPDATED_REFRESH_TOKEN_VALIDITY);
 
         restClientMockMvc.perform(put("/api/clients")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -331,6 +343,8 @@ public class ClientResourceIntTest {
         assertThat(encoder.matches(UPDATED_CLIENT_SECRET, testClient.getClientSecret())).isTrue();
         assertThat(testClient.getRoleKey()).isEqualTo(UPDATED_ROLE_KEY);
         assertThat(testClient.getDescription()).isEqualTo(UPDATED_DESCRIPTION);
+        assertThat(testClient.getAccessTokenValiditySeconds()).isEqualTo(UPDATED_ACCESS_TOKEN_VALIDITY);
+        assertThat(testClient.getRefreshTokenValiditySeconds()).isEqualTo(UPDATED_REFRESH_TOKEN_VALIDITY);
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced token lifecycle management with new refresh token validity configuration. Clients can now specify and persist refresh token validity duration alongside existing access token settings. These configuration changes are automatically applied during both client creation and update operations, enabling comprehensive control over token validity periods.

* **Chores**
  * Version updated to 2.2.90.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->