### PR TITLE
Hide clientSecret from logs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=uaa
 
-version=2.2.93
+version=2.2.94
 profile=dev
 
 # Build properties

--- a/src/main/java/com/icthh/xm/uaa/domain/Client.java
+++ b/src/main/java/com/icthh/xm/uaa/domain/Client.java
@@ -28,7 +28,7 @@ import java.util.List;
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @Getter
 @Setter
-@ToString(exclude = {"scopes"})
+@ToString(exclude = {"clientSecret", "scopes"})
 public class Client extends AbstractAuditingEntity implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/com/icthh/xm/uaa/service/dto/ClientDTO.java
+++ b/src/main/java/com/icthh/xm/uaa/service/dto/ClientDTO.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 import java.util.List;
 
 @AllArgsConstructor
-@ToString
+@ToString(exclude = "clientSecret")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Sensitive client secrets are no longer included in diagnostic string output for client records and client data transfer objects.
  * Client scopes are still excluded from client record string representations.
* **Chores**
  * Bumped the application version from `2.2.93` to `2.2.94`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->