### PR TITLE
Fix double load client during token retrieving

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=uaa
 
-version=2.2.96
+version=2.2.97
 profile=dev
 
 # Build properties

--- a/src/main/java/com/icthh/xm/uaa/security/DomainTokenServices.java
+++ b/src/main/java/com/icthh/xm/uaa/security/DomainTokenServices.java
@@ -246,11 +246,9 @@ public class DomainTokenServices implements AuthorizationServerTokenServices, Re
             authentication = new OAuth2Authentication(authentication.getOAuth2Request(), user);
         }
 
-        // Resolved once and reused below: both periods come from a single client details lookup.
         TokenValidity validity = tokenConstraintsService.getTokenValidity(authentication);
-        boolean reIssueRefreshToken = tenantPropertiesService.getTenantProps().getSecurity().isReIssueRefreshToken();
 
-        if (reIssueRefreshToken) {
+        if (tenantPropertiesService.getTenantProps().getSecurity().isReIssueRefreshToken()) {
             tokenStore.removeRefreshToken(refreshToken);
             refreshToken = createRefreshToken(authentication, validity.getRefreshTokenValiditySeconds());
         }
@@ -258,7 +256,7 @@ public class DomainTokenServices implements AuthorizationServerTokenServices, Re
         OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken,
             validity.getAccessTokenValiditySeconds());
         tokenStore.storeAccessToken(accessToken, authentication);
-        if (reIssueRefreshToken) {
+        if (tenantPropertiesService.getTenantProps().getSecurity().isReIssueRefreshToken()) {
             tokenStore.storeRefreshToken(accessToken.getRefreshToken(), authentication);
         }
         return accessToken;

--- a/src/main/java/com/icthh/xm/uaa/security/DomainTokenServices.java
+++ b/src/main/java/com/icthh/xm/uaa/security/DomainTokenServices.java
@@ -138,21 +138,24 @@ public class DomainTokenServices implements AuthorizationServerTokenServices, Re
             }
         }
 
+        TokenValidity validity = tokenConstraintsService.getTokenValidity(authentication);
+
         // Only create a new refresh token if there wasn't an existing one
         // associated with an expired access token.
         // Clients might be holding existing refresh tokens, so we re-use it in
         // the case that the old access token
         // expired.
         if (refreshToken == null) {
-            refreshToken = createRefreshToken(authentication);
+            refreshToken = createRefreshToken(authentication, validity.getRefreshTokenValiditySeconds());
         } else if (refreshToken instanceof ExpiringOAuth2RefreshToken) {
             ExpiringOAuth2RefreshToken expiring = (ExpiringOAuth2RefreshToken) refreshToken;
             if (System.currentTimeMillis() > expiring.getExpiration().getTime()) {
-                refreshToken = createRefreshToken(authentication);
+                refreshToken = createRefreshToken(authentication, validity.getRefreshTokenValiditySeconds());
             }
         }
 
-        OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken);
+        OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken,
+            validity.getAccessTokenValiditySeconds());
         tokenStore.storeAccessToken(accessToken, authentication);
         // In case it was modified
         refreshToken = accessToken.getRefreshToken();
@@ -243,14 +246,19 @@ public class DomainTokenServices implements AuthorizationServerTokenServices, Re
             authentication = new OAuth2Authentication(authentication.getOAuth2Request(), user);
         }
 
-        if (tenantPropertiesService.getTenantProps().getSecurity().isReIssueRefreshToken()) {
+        // Resolved once and reused below: both periods come from a single client details lookup.
+        TokenValidity validity = tokenConstraintsService.getTokenValidity(authentication);
+        boolean reIssueRefreshToken = tenantPropertiesService.getTenantProps().getSecurity().isReIssueRefreshToken();
+
+        if (reIssueRefreshToken) {
             tokenStore.removeRefreshToken(refreshToken);
-            refreshToken = createRefreshToken(authentication);
+            refreshToken = createRefreshToken(authentication, validity.getRefreshTokenValiditySeconds());
         }
 
-        OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken);
+        OAuth2AccessToken accessToken = createAccessToken(authentication, refreshToken,
+            validity.getAccessTokenValiditySeconds());
         tokenStore.storeAccessToken(accessToken, authentication);
-        if (tenantPropertiesService.getTenantProps().getSecurity().isReIssueRefreshToken()) {
+        if (reIssueRefreshToken) {
             tokenStore.storeRefreshToken(accessToken.getRefreshToken(), authentication);
         }
         return accessToken;
@@ -352,11 +360,10 @@ public class DomainTokenServices implements AuthorizationServerTokenServices, Re
         return true;
     }
 
-    private OAuth2RefreshToken createRefreshToken(OAuth2Authentication authentication) {
+    private OAuth2RefreshToken createRefreshToken(OAuth2Authentication authentication, int validitySeconds) {
         if (!tokenConstraintsService.isSupportRefreshToken(authentication.getOAuth2Request())) {
             return null;
         }
-        int validitySeconds = tokenConstraintsService.getRefreshTokenValiditySeconds(authentication);
         String value = UUID.randomUUID().toString();
         if (validitySeconds > 0) {
             return new DefaultExpiringOAuth2RefreshToken(value, new Date(System.currentTimeMillis()
@@ -365,9 +372,9 @@ public class DomainTokenServices implements AuthorizationServerTokenServices, Re
         return new DefaultOAuth2RefreshToken(value);
     }
 
-    private OAuth2AccessToken createAccessToken(OAuth2Authentication authentication, OAuth2RefreshToken refreshToken) {
+    private OAuth2AccessToken createAccessToken(OAuth2Authentication authentication, OAuth2RefreshToken refreshToken,
+                                                int validitySeconds) {
         DefaultOAuth2AccessToken token = new DefaultOAuth2AccessToken(UUID.randomUUID().toString());
-        int validitySeconds = tokenConstraintsService.getAccessTokenValiditySeconds(authentication);
         if (validitySeconds > 0) {
             token.setExpiration(new Date(System.currentTimeMillis() + (validitySeconds * 1000L)));
         }

--- a/src/main/java/com/icthh/xm/uaa/security/TokenConstraintsService.java
+++ b/src/main/java/com/icthh/xm/uaa/security/TokenConstraintsService.java
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Optional.ofNullable;
@@ -38,7 +39,7 @@ public class TokenConstraintsService {
     private final ClientDetailsService clientDetailsService;
 
     public TokenValidity getTokenValidity(OAuth2Authentication authentication) {
-        ClientDetails client = loadClient(authentication);
+        Optional<ClientDetails> client = loadClient(authentication);
         return new TokenValidity(
             resolveAccessTokenValiditySeconds(authentication, client),
             resolveRefreshTokenValiditySeconds(authentication, client));
@@ -54,13 +55,14 @@ public class TokenConstraintsService {
         return resolveAccessTokenValiditySeconds(authentication, loadClient(authentication));
     }
 
-    private ClientDetails loadClient(OAuth2Authentication authentication) {
-        return ofNullable(authentication.getOAuth2Request().getClientId())
-            .map(clientDetailsService::loadClientByClientId)
-            .orElse(null);
+    private Optional<ClientDetails> loadClient(OAuth2Authentication authentication) {
+        String clientId = authentication.getOAuth2Request().getClientId();
+        return ofNullable(clientId)
+            .map(clientDetailsService::loadClientByClientId);
     }
 
-    private int resolveAccessTokenValiditySeconds(OAuth2Authentication authentication, ClientDetails client) {
+    private int resolveAccessTokenValiditySeconds(OAuth2Authentication authentication,
+                                                  Optional<ClientDetails> client) {
         Object principal = authentication.getPrincipal();
         if (principal instanceof DomainUserDetails) {
             Integer userValidity = DomainUserDetails.class.cast(principal).getAccessTokenValiditySeconds();
@@ -69,9 +71,9 @@ public class TokenConstraintsService {
             }
         }
 
-        return ofNullable(client)
+        return client
             .map(ClientDetails::getAccessTokenValiditySeconds)
-            .orElseGet(this::getTenantRelatedAccessTokenValiditySeconds);
+            .orElse(getTenantRelatedAccessTokenValiditySeconds());
     }
 
     public int getAccessTokenValiditySeconds(DomainUserDetails userDetails) {
@@ -109,26 +111,25 @@ public class TokenConstraintsService {
         return resolveRefreshTokenValiditySeconds(authentication, loadClient(authentication));
     }
 
-    private int resolveRefreshTokenValiditySeconds(OAuth2Authentication authentication, ClientDetails client) {
+    private int resolveRefreshTokenValiditySeconds(OAuth2Authentication authentication,
+                                                   Optional<ClientDetails> client) {
+        Integer validity;
         Object principal = authentication.getPrincipal();
         if (principal instanceof DomainUserDetails) {
-            Integer userValidity = DomainUserDetails.class.cast(principal).getRefreshTokenValiditySeconds();
-            if (userValidity != null) {
-                return userValidity;
+            validity = DomainUserDetails.class.cast(principal).getRefreshTokenValiditySeconds();
+            if (validity != null) {
+                return validity;
             }
         }
 
-        return ofNullable(client)
+        return client
             .map(ClientDetails::getRefreshTokenValiditySeconds)
-            .orElseGet(this::getTenantRelatedRefreshTokenValiditySeconds);
-    }
-
-    private int getTenantRelatedRefreshTokenValiditySeconds() {
-        return firstNonNull(
-            tenantPropertiesService.getTenantProps().getSecurity().getRefreshTokenValiditySeconds(),
-            applicationProperties.getSecurity().getRefreshTokenValiditySeconds(),
-            defaultRefreshTokenValiditySeconds
-        );
+            .orElse(firstNonNull(
+                    tenantPropertiesService.getTenantProps().getSecurity().getRefreshTokenValiditySeconds(),
+                    applicationProperties.getSecurity().getRefreshTokenValiditySeconds(),
+                    defaultRefreshTokenValiditySeconds
+                )
+            );
     }
 
     /**

--- a/src/main/java/com/icthh/xm/uaa/security/TokenConstraintsService.java
+++ b/src/main/java/com/icthh/xm/uaa/security/TokenConstraintsService.java
@@ -10,9 +10,7 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.stereotype.Service;
 
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
@@ -39,6 +37,13 @@ public class TokenConstraintsService {
 
     private final ClientDetailsService clientDetailsService;
 
+    public TokenValidity getTokenValidity(OAuth2Authentication authentication) {
+        ClientDetails client = loadClient(authentication);
+        return new TokenValidity(
+            resolveAccessTokenValiditySeconds(authentication, client),
+            resolveRefreshTokenValiditySeconds(authentication, client));
+    }
+
     /**
      * The access token validity period in seconds.
      *
@@ -46,6 +51,16 @@ public class TokenConstraintsService {
      * @return the access token validity period in seconds
      */
     public int getAccessTokenValiditySeconds(OAuth2Authentication authentication) {
+        return resolveAccessTokenValiditySeconds(authentication, loadClient(authentication));
+    }
+
+    private ClientDetails loadClient(OAuth2Authentication authentication) {
+        return ofNullable(authentication.getOAuth2Request().getClientId())
+            .map(clientDetailsService::loadClientByClientId)
+            .orElse(null);
+    }
+
+    private int resolveAccessTokenValiditySeconds(OAuth2Authentication authentication, ClientDetails client) {
         Object principal = authentication.getPrincipal();
         if (principal instanceof DomainUserDetails) {
             Integer userValidity = DomainUserDetails.class.cast(principal).getAccessTokenValiditySeconds();
@@ -54,15 +69,9 @@ public class TokenConstraintsService {
             }
         }
 
-        return loadClientInfo(authentication, ClientDetails::getAccessTokenValiditySeconds)
-            .orElse(getTenantRelatedAccessTokenValiditySeconds());
-    }
-
-    private <T> Optional<T> loadClientInfo(OAuth2Authentication authentication, Function<ClientDetails, T> consumer) {
-        String clientId = authentication.getOAuth2Request().getClientId();
-        return ofNullable(clientId)
-            .map(clientDetailsService::loadClientByClientId)
-            .map(consumer);
+        return ofNullable(client)
+            .map(ClientDetails::getAccessTokenValiditySeconds)
+            .orElseGet(this::getTenantRelatedAccessTokenValiditySeconds);
     }
 
     public int getAccessTokenValiditySeconds(DomainUserDetails userDetails) {
@@ -97,21 +106,28 @@ public class TokenConstraintsService {
      * @return the refresh token validity period in seconds
      */
     public int getRefreshTokenValiditySeconds(OAuth2Authentication authentication) {
-        Integer validity;
+        return resolveRefreshTokenValiditySeconds(authentication, loadClient(authentication));
+    }
+
+    private int resolveRefreshTokenValiditySeconds(OAuth2Authentication authentication, ClientDetails client) {
         Object principal = authentication.getPrincipal();
         if (principal instanceof DomainUserDetails) {
-            validity = DomainUserDetails.class.cast(principal).getRefreshTokenValiditySeconds();
-            if (validity != null) {
-                return validity;
+            Integer userValidity = DomainUserDetails.class.cast(principal).getRefreshTokenValiditySeconds();
+            if (userValidity != null) {
+                return userValidity;
             }
         }
 
-        return loadClientInfo(authentication, ClientDetails::getRefreshTokenValiditySeconds)
-            .orElse(firstNonNull(
-                tenantPropertiesService.getTenantProps().getSecurity().getRefreshTokenValiditySeconds(),
-                applicationProperties.getSecurity().getRefreshTokenValiditySeconds(),
-                defaultRefreshTokenValiditySeconds
-            )
+        return ofNullable(client)
+            .map(ClientDetails::getRefreshTokenValiditySeconds)
+            .orElseGet(this::getTenantRelatedRefreshTokenValiditySeconds);
+    }
+
+    private int getTenantRelatedRefreshTokenValiditySeconds() {
+        return firstNonNull(
+            tenantPropertiesService.getTenantProps().getSecurity().getRefreshTokenValiditySeconds(),
+            applicationProperties.getSecurity().getRefreshTokenValiditySeconds(),
+            defaultRefreshTokenValiditySeconds
         );
     }
 

--- a/src/main/java/com/icthh/xm/uaa/security/TokenConstraintsService.java
+++ b/src/main/java/com/icthh/xm/uaa/security/TokenConstraintsService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
@@ -41,8 +42,8 @@ public class TokenConstraintsService {
     public TokenValidity getTokenValidity(OAuth2Authentication authentication) {
         Optional<ClientDetails> client = loadClient(authentication);
         return new TokenValidity(
-            resolveAccessTokenValiditySeconds(authentication, client),
-            resolveRefreshTokenValiditySeconds(authentication, client));
+            resolveAccessTokenValiditySeconds(authentication, clientAccessTokenValiditySeconds(() -> client)),
+            resolveRefreshTokenValiditySeconds(authentication, clientRefreshTokenValiditySeconds(() -> client)));
     }
 
     /**
@@ -52,7 +53,8 @@ public class TokenConstraintsService {
      * @return the access token validity period in seconds
      */
     public int getAccessTokenValiditySeconds(OAuth2Authentication authentication) {
-        return resolveAccessTokenValiditySeconds(authentication, loadClient(authentication));
+        return resolveAccessTokenValiditySeconds(authentication,
+            clientAccessTokenValiditySeconds(() -> loadClient(authentication)));
     }
 
     private Optional<ClientDetails> loadClient(OAuth2Authentication authentication) {
@@ -61,8 +63,14 @@ public class TokenConstraintsService {
             .map(clientDetailsService::loadClientByClientId);
     }
 
+    private Supplier<Integer> clientAccessTokenValiditySeconds(Supplier<Optional<ClientDetails>> client) {
+        return () -> client.get()
+            .map(ClientDetails::getAccessTokenValiditySeconds)
+            .orElse(getTenantRelatedAccessTokenValiditySeconds());
+    }
+
     private int resolveAccessTokenValiditySeconds(OAuth2Authentication authentication,
-                                                  Optional<ClientDetails> client) {
+                                                  Supplier<Integer> clientValidity) {
         Object principal = authentication.getPrincipal();
         if (principal instanceof DomainUserDetails) {
             Integer userValidity = DomainUserDetails.class.cast(principal).getAccessTokenValiditySeconds();
@@ -71,9 +79,7 @@ public class TokenConstraintsService {
             }
         }
 
-        return client
-            .map(ClientDetails::getAccessTokenValiditySeconds)
-            .orElse(getTenantRelatedAccessTokenValiditySeconds());
+        return clientValidity.get();
     }
 
     public int getAccessTokenValiditySeconds(DomainUserDetails userDetails) {
@@ -108,11 +114,23 @@ public class TokenConstraintsService {
      * @return the refresh token validity period in seconds
      */
     public int getRefreshTokenValiditySeconds(OAuth2Authentication authentication) {
-        return resolveRefreshTokenValiditySeconds(authentication, loadClient(authentication));
+        return resolveRefreshTokenValiditySeconds(authentication,
+            clientRefreshTokenValiditySeconds(() -> loadClient(authentication)));
+    }
+
+    private Supplier<Integer> clientRefreshTokenValiditySeconds(Supplier<Optional<ClientDetails>> client) {
+        return () -> client.get()
+            .map(ClientDetails::getRefreshTokenValiditySeconds)
+            .orElse(firstNonNull(
+                    tenantPropertiesService.getTenantProps().getSecurity().getRefreshTokenValiditySeconds(),
+                    applicationProperties.getSecurity().getRefreshTokenValiditySeconds(),
+                    defaultRefreshTokenValiditySeconds
+                )
+            );
     }
 
     private int resolveRefreshTokenValiditySeconds(OAuth2Authentication authentication,
-                                                   Optional<ClientDetails> client) {
+                                                   Supplier<Integer> clientValidity) {
         Integer validity;
         Object principal = authentication.getPrincipal();
         if (principal instanceof DomainUserDetails) {
@@ -122,14 +140,7 @@ public class TokenConstraintsService {
             }
         }
 
-        return client
-            .map(ClientDetails::getRefreshTokenValiditySeconds)
-            .orElse(firstNonNull(
-                    tenantPropertiesService.getTenantProps().getSecurity().getRefreshTokenValiditySeconds(),
-                    applicationProperties.getSecurity().getRefreshTokenValiditySeconds(),
-                    defaultRefreshTokenValiditySeconds
-                )
-            );
+        return clientValidity.get();
     }
 
     /**

--- a/src/main/java/com/icthh/xm/uaa/security/TokenConstraintsService.java
+++ b/src/main/java/com/icthh/xm/uaa/security/TokenConstraintsService.java
@@ -66,7 +66,7 @@ public class TokenConstraintsService {
     private Supplier<Integer> clientAccessTokenValiditySeconds(Supplier<Optional<ClientDetails>> client) {
         return () -> client.get()
             .map(ClientDetails::getAccessTokenValiditySeconds)
-            .orElse(getTenantRelatedAccessTokenValiditySeconds());
+            .orElseGet(this::getTenantRelatedAccessTokenValiditySeconds);
     }
 
     private int resolveAccessTokenValiditySeconds(OAuth2Authentication authentication,
@@ -121,7 +121,7 @@ public class TokenConstraintsService {
     private Supplier<Integer> clientRefreshTokenValiditySeconds(Supplier<Optional<ClientDetails>> client) {
         return () -> client.get()
             .map(ClientDetails::getRefreshTokenValiditySeconds)
-            .orElse(firstNonNull(
+            .orElseGet(() -> firstNonNull(
                     tenantPropertiesService.getTenantProps().getSecurity().getRefreshTokenValiditySeconds(),
                     applicationProperties.getSecurity().getRefreshTokenValiditySeconds(),
                     defaultRefreshTokenValiditySeconds

--- a/src/main/java/com/icthh/xm/uaa/security/TokenValidity.java
+++ b/src/main/java/com/icthh/xm/uaa/security/TokenValidity.java
@@ -1,0 +1,13 @@
+package com.icthh.xm.uaa.security;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenValidity {
+
+    private final int accessTokenValiditySeconds;
+
+    private final int refreshTokenValiditySeconds;
+}

--- a/src/main/java/com/icthh/xm/uaa/service/ClientService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/ClientService.java
@@ -195,6 +195,7 @@ public class ClientService {
     }
 
     @IgnoreLogginAspect
+    @Transactional(readOnly = true)
     public Client getClient(String clientId) {
         return clientRepository.findOneByClientId(clientId);
     }

--- a/src/test/java/com/icthh/xm/uaa/security/TokenConstraintsServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/uaa/security/TokenConstraintsServiceUnitTest.java
@@ -258,6 +258,23 @@ public class TokenConstraintsServiceUnitTest {
     }
 
     // -----------------------------------------------------------------------
+    // Tests: both validity periods resolved from a single client lookup
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void givenBothClientConfigs_whenGetTokenValidity_thenReturnsBothFromSingleClientLookup() {
+        int clientAccess = 900;
+        int clientRefresh = 28800;
+        ClientDetails clientDetails = clientWithValidity(clientAccess, clientRefresh);
+        when(clientDetailsService.loadClientByClientId(CLIENT_A)).thenReturn(clientDetails);
+
+        TokenValidity result = service.getTokenValidity(buildAuthentication(CLIENT_A));
+
+        assertThat(result.getAccessTokenValiditySeconds()).isEqualTo(clientAccess);
+        assertThat(result.getRefreshTokenValiditySeconds()).isEqualTo(clientRefresh);
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when issuing and refreshing access and refresh tokens.
  * Ensured token expiration settings are resolved once and applied consistently during each token operation.
  * Applied the correct token validity settings based on available account, client, tenant, and application configuration.

* **Chores**
  * Updated the application version to 2.2.96.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->