### PR TITLE
feat(permissions): Enhance ObjectMapper configuration to exclude null…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 rootProject.name=uaa
 
-version=2.2.98
+version=2.2.99
 profile=dev
 
 # Build properties

--- a/src/main/java/com/icthh/xm/uaa/service/TenantRoleService.java
+++ b/src/main/java/com/icthh/xm/uaa/service/TenantRoleService.java
@@ -1,5 +1,6 @@
 package com.icthh.xm.uaa.service;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -65,7 +66,8 @@ public class TenantRoleService {
     @Value("${xm-permission.custom-privileges-path:}")
     private String customPrivilegesPath;
 
-    private ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    private ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL);
     private final PermissionProperties permissionProperties;
     private final TenantConfigRepository tenantConfigRepository;
     private final UserRepository userRepository;

--- a/src/test/java/com/icthh/xm/uaa/service/TenantRoleServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/uaa/service/TenantRoleServiceUnitTest.java
@@ -400,7 +400,9 @@ public class TenantRoleServiceUnitTest {
         ArgumentCaptor<String> yamlCaptor = ArgumentCaptor.forClass(String.class);
         verify(tenantConfigRepository).updateConfigFullPath(eq(XM_TENANT), eq(PERMISSIONS_PATH), yamlCaptor.capture());
 
-        assertThat(yamlCaptor.getValue()).doesNotContain(": null");
+        assertThat(yamlCaptor.getValue())
+            .contains("ATTACHMENT.CREATE")
+            .doesNotContain(": null");
     }
 
     @Test(expected = IllegalStateException.class)

--- a/src/test/java/com/icthh/xm/uaa/service/TenantRoleServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/uaa/service/TenantRoleServiceUnitTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -373,6 +374,33 @@ public class TenantRoleServiceUnitTest {
 
         verify(tenantConfigRepository)
             .updateConfigFullPath(XM_TENANT, PERMISSIONS_PATH, readConfigFile("/RoleResourceIntTest/updatedPermissions.yml"));
+    }
+
+    @Test
+    public void updateRole_nullPermissionProperties_shouldBeOmittedFromYaml() {
+        updateRoleMoks();
+
+        RoleDTO roleDto = new RoleDTO();
+        roleDto.setRoleKey("ROLE_ADMIN");
+        roleDto.setDescription("Role with null permission fields");
+
+        PermissionDTO permissionWithNulls = new PermissionDTO();
+        permissionWithNulls.setMsName("uaa");
+        permissionWithNulls.setRoleKey("ROLE_ADMIN");
+        permissionWithNulls.setPrivilegeKey("ATTACHMENT.CREATE");
+        permissionWithNulls.setEnabled(false);
+
+        roleDto.setPermissions(singletonList(permissionWithNulls));
+
+        TenantProperties tenantProperties = new TenantProperties();
+        when(tenantPropertiesService.getTenantProps()).thenReturn(tenantProperties);
+
+        tenantRoleService.updateRole(roleDto);
+
+        ArgumentCaptor<String> yamlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(tenantConfigRepository).updateConfigFullPath(eq(XM_TENANT), eq(PERMISSIONS_PATH), yamlCaptor.capture());
+
+        assertThat(yamlCaptor.getValue()).doesNotContain(": null");
     }
 
     @Test(expected = IllegalStateException.class)

--- a/src/test/resources/RoleResourceIntTest/updatedPermissions.yml
+++ b/src/test/resources/RoleResourceIntTest/updatedPermissions.yml
@@ -4,20 +4,13 @@ uaa:
   - privilegeKey: "ATTACHMENT.CREATE"
     disabled: true
     deleted: false
-    envCondition: null
-    resourceCondition: null
-    reactionStrategy: null
   - privilegeKey: "MISSING.PRIVILEGE"
     disabled: false
     deleted: false
-    envCondition: null
-    resourceCondition: null
     reactionStrategy: "SKIP"
   ROLE_ANONYMOUS:
   - privilegeKey: "ATTACHMENT.CREATE"
     disabled: false
     deleted: false
-    envCondition: null
-    resourceCondition: null
     reactionStrategy: "SKIP"
 

--- a/src/test/resources/config/tenants/XM/permissions_removeDefault_expected.yml
+++ b/src/test/resources/config/tenants/XM/permissions_removeDefault_expected.yml
@@ -4,15 +4,10 @@ dashboard:
   - privilegeKey: "DASHBOARD.CREATE"
     disabled: false
     deleted: false
-    envCondition: null
-    resourceCondition: null
-    reactionStrategy: null
   ROLE_ANONYMOUS:
   - privilegeKey: "DASHBOARD.GET_LIST.ITEM"
     disabled: true
     deleted: false
-    envCondition: null
-    resourceCondition: null
     reactionStrategy: "SKIP"
 entity:
   ROLE_ADMIN: []
@@ -20,22 +15,14 @@ entity:
   - privilegeKey: "ATTACHMENT.CREATE"
     disabled: false
     deleted: false
-    envCondition: null
-    resourceCondition: null
     reactionStrategy: "SKIP"
 uaa:
   ROLE_ADMIN:
   - privilegeKey: "ACCOUNT.CREATE"
     disabled: false
     deleted: false
-    envCondition: null
-    resourceCondition: null
-    reactionStrategy: null
   ROLE_ANONYMOUS:
   - privilegeKey: "ACCOUNT.GET"
     disabled: false
     deleted: false
-    envCondition: null
-    resourceCondition: null
-    reactionStrategy: null
 


### PR DESCRIPTION
… values in TenantRoleService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML serialization by omitting optional properties with null values, producing cleaner role and permission updates.
  * Added regression coverage to verify null fields are excluded while configured permission settings remain unchanged.

* **Chores**
  * Updated the project version to 2.2.99.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->